### PR TITLE
 #148532871 paginate documents

### DIFF
--- a/client/actions/documentsAction.js
+++ b/client/actions/documentsAction.js
@@ -71,9 +71,14 @@ export function createDocument(document) {
  * @export
  * @returns {promise} -
  */
-export function getDocuments() {
+export function getDocuments(offset = 0, limit = 11) {
   return dispatch => (
-    axios.get('/api/documents')
+    axios.get('/api/documents', {
+      params: {
+        offset,
+        limit
+      }
+    })
   ).then(
     (response) => {
       dispatch(addAllDocumentsToState(response.data));
@@ -90,7 +95,10 @@ export function getDocuments() {
  */
 export function deleteDocuments() {
   return (dispatch) => {
-    dispatch(addAllDocumentsToState([]));
+    dispatch(addAllDocumentsToState({
+      rows: [],
+      count: 0
+    }));
   };
 }
 

--- a/client/components/body/document/DocListing.jsx
+++ b/client/components/body/document/DocListing.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import _, { isEmpty } from 'lodash';
+import ReactPaginate from 'react-paginate';
 import { createDocument,
   getDocuments,
  } from '../../../actions/documentsAction';
@@ -27,18 +28,22 @@ class DocListing extends React.Component {
   constructor(props) {
     super(props);
     const { documents } = this.props;
+    this.docsPerPage = 11;
     this.state = {
       title: '',
       content: '',
       access: 1,
       errors: {},
-      documents,
+      documents: documents.rows,
+      pageCount: Math.ceil(documents.count / this.docsPerPage),
+      offset: 0
     };
     this.openModal = this.openModal.bind(this);
     this.handleEditorChange = this.handleEditorChange.bind(this);
     this.onChange = this.onChange.bind(this);
     this.saveDocument = this.saveDocument.bind(this);
     this.cancelDocument = this.cancelDocument.bind(this);
+    this.handlePageClick = this.handlePageClick.bind(this);
     // this.setDocumentToState = this.setDocumentToState.bind(this);
   }
 
@@ -63,8 +68,9 @@ class DocListing extends React.Component {
    */
   componentWillReceiveProps(nextProps) {
     this.setState({
-      documents: nextProps.documents,
-      errors: nextProps.errors
+      documents: nextProps.documents.rows,
+      errors: nextProps.errors,
+      pageCount: Math.ceil(nextProps.documents.count / this.docsPerPage)
     });
   }
 
@@ -202,6 +208,22 @@ class DocListing extends React.Component {
   }
 
   /**
+   * Handles pagination
+   * @method handlePageClick
+   * @param {any} data
+   * @return {void}
+   * @memberOf DocListing
+   */
+  handlePageClick(data) {
+    const selected = data.selected;
+    const offset = Math.ceil(selected * this.docsPerPage);
+
+    this.setState({ offset }, () => {
+      this.props.getDocuments(this.state.offset);
+    });
+  }
+
+  /**
    * Renders JSX component
    * @method render
    * @returns {void} - component
@@ -235,6 +257,21 @@ class DocListing extends React.Component {
           </div>
           {Display}
           <div className="clear" />
+        </div>
+        <div className="row">
+          <ReactPaginate
+            previousLabel={'previous'}
+            nextLabel={'next'}
+            breakLabel={<a href="">...</a>}
+            breakClassName={'break-me'}
+            pageCount={this.state.pageCount}
+            marginPagesDisplayed={2}
+            pageRangeDisplayed={5}
+            onPageChange={this.handlePageClick}
+            containerClassName={'pagination'}
+            subContainerClassName={'pages pagination'}
+            activeClassName={'active'}
+          />
         </div>
         <div id="modal1" className="modal modal-fixed-footer">
           <div className="modal-content">
@@ -276,7 +313,8 @@ class DocListing extends React.Component {
               <div className="clear" />
             </div>
             <TinyMceComponent
-              id="tinymce" handleEditorChange={this.handleEditorChange}
+              id="tinymce"
+              handleEditorChange={this.handleEditorChange}
               content={this.state.content}
             />
           </div>

--- a/client/reducers/documents.js
+++ b/client/reducers/documents.js
@@ -3,19 +3,28 @@ import {
   SET_DOCUMENTS_TO_STATE,
 } from '../actions/type';
 
-const initialState = [];
+const initialState = {
+  rows: [],
+  count: 0
+};
 
 export default (state = initialState, action = {}) => {
   switch (action.type) {
     case ADD_TO_DOCUMENTS:
-      return [
-        action.document,
-        ...state
-      ];
+      return {
+        rows: [
+          action.document,
+          ...state.rows
+        ],
+        count: state.count + 1
+      };
     case SET_DOCUMENTS_TO_STATE:
-      return [
-        ...(action.documents)
-      ];
+      return {
+        rows: [
+          ...action.documents.rows
+        ],
+        count: action.documents.count
+      };
     default: return state;
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1062,6 +1062,11 @@
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
       "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc="
     },
+    "classnames": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+    },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
@@ -5357,6 +5362,11 @@
       "resolved": "https://registry.npmjs.org/react/-/react-15.5.4.tgz",
       "integrity": "sha1-+oPrAVBqsjfNwcjDsc6o3gEr8Ec="
     },
+    "react-addons-create-fragment": {
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/react-addons-create-fragment/-/react-addons-create-fragment-15.6.0.tgz",
+      "integrity": "sha1-r5GiKx+wld0B8a+6Q7/Q71idiyA="
+    },
     "react-dom": {
       "version": "15.5.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.5.4.tgz",
@@ -5381,6 +5391,11 @@
           "dev": true
         }
       }
+    },
+    "react-paginate": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-4.4.3.tgz",
+      "integrity": "sha1-EYF+zmKPpZxUot95aMhU7WS5kHc="
     },
     "react-redux": {
       "version": "5.0.5",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "query-string": "^4.3.4",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
+    "react-paginate": "^4.4.3",
     "react-redux": "^5.0.5",
     "react-router-dom": "^4.1.1",
     "react-tinymce": "^0.5.1",

--- a/server/routes/documents.js
+++ b/server/routes/documents.js
@@ -107,7 +107,7 @@ router.get('/', authenticateUser, (req, res) => {
     };
   }
   // query the database for documents
-  Document.findAll(queryParams)
+  Document.findAndCountAll(queryParams)
   .then((doc) => {
     // reutns error if no document is found
     if (doc.length === 0) {

--- a/server/routes/search.js
+++ b/server/routes/search.js
@@ -38,7 +38,7 @@ router.get('/documents', authenticateUser, (req, res) => {
   }
   const userRoleId = req.authenticatedUser.roleId;
   const userId = req.authenticatedUser.id;
-  Document.findAll({
+  Document.findAndCountAll({
     where: {
       $and: {
         title: {


### PR DESCRIPTION
- add react-paginate to allow pagination of documents
- enable pagination
[Finishes #148532871]
#### What does this PR do?
This PR makes use of the pagination endpoint to limit documents displayed to users per page to 11

#### Description of Task to be completed?
- display 11 documents per page

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
 #148532871 Implement Search

#### Screenshots (if appropriate)
N/A

#### Questions:
N/A